### PR TITLE
Remove 'scp' dependency

### DIFF
--- a/examples/hcloud-k3s/README.md
+++ b/examples/hcloud-k3s/README.md
@@ -1,0 +1,15 @@
+#  K3S example for Hetzner-Cloud
+
+Configuration in this directory creates a k3s cluster resources including network, subnet and instances.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.

--- a/examples/hcloud-k3s/instances.tf
+++ b/examples/hcloud-k3s/instances.tf
@@ -1,0 +1,73 @@
+resource "hcloud_ssh_key" "default" {
+  name       = "K3S terraform module - Provisionning SSH key"
+  public_key = var.ssh_key
+}
+
+resource "hcloud_network" "k3s" {
+  name     = "k3s-network"
+  ip_range = "10.0.0.0/8"
+}
+
+resource "hcloud_network_subnet" "k3s_nodes" {
+  type         = "server"
+  network_id   = hcloud_network.k3s.id
+  network_zone = "eu-central"
+  ip_range     = "10.254.1.0/24"
+}
+
+resource "hcloud_network_subnet" "k3s_internal" {
+  type         = "server"
+  network_id   = hcloud_network.k3s.id
+  network_zone = "eu-central"
+  ip_range     = "10.0.0.0/15"
+}
+
+data "hcloud_image" "ubuntu" {
+  name = "ubuntu-18.04"
+}
+
+resource "hcloud_server" "master" {
+  name = "k3s-master"
+
+  image       = data.hcloud_image.ubuntu.name
+  server_type = "cx11-ceph"
+
+  ssh_keys = [
+    hcloud_ssh_key.default.id
+  ]
+  labels = {
+    provisioner = "terraform",
+    engine      = "k3s",
+    node_type   = "master"
+  }
+}
+
+resource "hcloud_server_network" "master_network" {
+  server_id  = hcloud_server.master.id
+  network_id = hcloud_network.k3s.id
+  ip         = cidrhost(hcloud_network_subnet.k3s_nodes.ip_range, 1)
+}
+
+resource "hcloud_server" "minions" {
+  count = var.minions_num
+  name  = "k3s-minion-${count.index}"
+
+  image       = data.hcloud_image.ubuntu.name
+  server_type = "cx11-ceph"
+
+  ssh_keys = [
+    hcloud_ssh_key.default.id
+  ]
+  labels = {
+    provisioner = "terraform",
+    engine      = "k3s",
+    node_type   = "minion"
+  }
+}
+
+resource "hcloud_server_network" "minions_network" {
+  count      = length(hcloud_server.minions)
+  server_id  = hcloud_server.minions[count.index].id
+  network_id = hcloud_network.k3s.id
+  ip         = cidrhost(hcloud_network_subnet.k3s_nodes.ip_range, count.index + 2)
+}

--- a/examples/hcloud-k3s/main.tf
+++ b/examples/hcloud-k3s/main.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = "~> 0.12.0"
+}
+
+provider "hcloud" {}
+
+module "k3s" {
+  source = "xunleii/k3s/module"
+
+  k3s_version          = "latest"
+  cluster_cidr         = "10.0.0.0/16"
+  cluster_service_cidr = "10.1.0.0/16"
+
+  master_node = {
+    ip = hcloud_server_network.master_network.ip
+    connection = {
+      host = hcloud_server.master.ipv4_address
+    }
+  }
+
+  minion_nodes = {
+    for i in range(length(hcloud_server.minions)) :
+    hcloud_server.minions[i].name => {
+      ip = hcloud_server_network.minions_network[i].ip
+      connection = {
+        host = hcloud_server.minions[i].ipv4_address
+      }
+    }
+  }
+}

--- a/examples/hcloud-k3s/main.tf
+++ b/examples/hcloud-k3s/main.tf
@@ -10,7 +10,7 @@ module "k3s" {
   k3s_version          = "latest"
   cluster_cidr         = "10.0.0.0/16"
   cluster_service_cidr = "10.1.0.0/16"
-  drain_timeout = "30s"
+  drain_timeout        = "30s"
 
   master_node = {
     ip = hcloud_server_network.master_network.ip

--- a/examples/hcloud-k3s/main.tf
+++ b/examples/hcloud-k3s/main.tf
@@ -10,6 +10,7 @@ module "k3s" {
   k3s_version          = "latest"
   cluster_cidr         = "10.0.0.0/16"
   cluster_service_cidr = "10.1.0.0/16"
+  drain_timeout = "30s"
 
   master_node = {
     ip = hcloud_server_network.master_network.ip

--- a/examples/hcloud-k3s/variables.tf
+++ b/examples/hcloud-k3s/variables.tf
@@ -1,0 +1,9 @@
+variable "ssh_key" {
+  description = "SSH public Key content needed to provision the instances."
+  type        = "string"
+}
+
+variable "minions_num" {
+  description = "Number of minion nodes."
+  default     = 3
+}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 0.12"
+}
+
+resource "random_string" "k3s_cluster_secret" {
+  length  = 48
+  special = false
 }

--- a/master.tf
+++ b/master.tf
@@ -31,7 +31,7 @@ locals {
 
 resource "null_resource" "k3s_master" {
   triggers = {
-    master_ip           = sha1(var.master_node.ip)
+    master_ip    = sha1(var.master_node.ip)
     install_args = sha1(local.master_install_args)
   }
 

--- a/minions.tf
+++ b/minions.tf
@@ -115,7 +115,7 @@ resource "null_resource" "k3s_minions_uninstaller" {
   for_each = var.minion_nodes
 
   triggers = {
-    minion    = null_resource.k3s_minions[each.key].id
+    minion = null_resource.k3s_minions[each.key].id
   }
 
   connection {

--- a/minions.tf
+++ b/minions.tf
@@ -116,7 +116,6 @@ resource "null_resource" "k3s_minions_uninstaller" {
 
   triggers = {
     minion    = null_resource.k3s_minions[each.key].id
-    minion_ip = each.value.ip
   }
 
   connection {
@@ -154,8 +153,8 @@ resource "null_resource" "k3s_minions_uninstaller" {
   provisioner "remote-exec" {
     when = "destroy"
     inline = [
-      "NODE=$(kubectl get node -l 'k3s.io/internal-ip = ${self.triggers.minion_ip}' | tail -n 1 | awk '{printf $1}')",
-      "kubectl drain $${NODE} --force --delete-local-data --ignore-daemonsets",
+      "NODE=$(kubectl get node -l 'k3s.io/internal-ip = ${null_resource.k3s_minions[each.key].triggers.minion_ip}' | tail -n 1 | awk '{printf $1}')",
+      "kubectl drain $${NODE} --force --delete-local-data --ignore-daemonsets --timeout ${var.drain_timeout}",
       "kubectl delete node $${NODE}",
       "sed -i \"/$${NODE}$/d\" /var/lib/rancher/k3s/server/cred/node-passwd",
     ]

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "master_node" {
   })
 }
 
+variable "drain_timeout" {
+  description = "The length of time to wait before giving up the node draining. Infinite by default."
+  type = string
+  default = "0s"
+}
+
 variable "minion_nodes" {
   description = "List of minion configuration nodes."
   type = map(object({

--- a/variables.tf
+++ b/variables.tf
@@ -38,8 +38,8 @@ variable "master_node" {
 
 variable "drain_timeout" {
   description = "The length of time to wait before giving up the node draining. Infinite by default."
-  type = string
-  default = "0s"
+  type        = string
+  default     = "0s"
 }
 
 variable "minion_nodes" {

--- a/version.tf
+++ b/version.tf
@@ -3,5 +3,5 @@ data "http" "k3s_version" {
 }
 
 locals {
-  k3s_version = "${var.k3s_version == "latest" ? "${jsondecode(data.http.k3s_version.body).tag_name}" : var.k3s_version}"
+  k3s_version = var.k3s_version == "latest" ? jsondecode(data.http.k3s_version.body).tag_name : var.k3s_version
 }


### PR DESCRIPTION
This PR remove the `scp` dependency, required to share the k3s token through all nodes.  
Fix at the same time the TF crash during `terraform destroy`

> close https://github.com/xunleii/terraform-module-k3s/issues/3