### PR TITLE
fix: use k3s update channels for latest releases instead of github

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "depends_on_" {
 }
 
 variable k3s_version {
-  description = "Specify the k3s version."
+  description = "Specify the k3s version. You can choose from the following release channels or pin the version directly"
   type        = string
   default     = "latest"
 }

--- a/version.tf
+++ b/version.tf
@@ -1,14 +1,14 @@
 // Fetch the last version of k3s
 data "http" "k3s_version" {
-  url = "https://api.github.com/repos/rancher/k3s/releases/latest"
+  url = "https://update.k3s.io/v1-release/channels"
 }
 
 // Fetch the k3s installation script
 data "http" "k3s_installer" {
-  url = "https://raw.githubusercontent.com/rancher/k3s/${jsondecode(data.http.k3s_version.body).tag_name}/install.sh"
+  url = "https://raw.githubusercontent.com/rancher/k3s/${jsondecode(data.http.k3s_version.body).data[1].latest}/install.sh"
 }
 
 locals {
   // Use the fetched version if 'lastest' is specified
-  k3s_version = var.k3s_version == "latest" ? jsondecode(data.http.k3s_version.body).tag_name : var.k3s_version
+  k3s_version = var.k3s_version == "latest" ? jsondecode(data.http.k3s_version.body).data[1].latest : var.k3s_version
 }


### PR DESCRIPTION
Hey @xunleii,
thanks for this awesome terraform module. I did a fix to fetch the latest release rancher directly. 

Closes #27 