### PR TITLE
fix: fix formatting step issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,6 @@ resource "random_password" "k3s_cluster_secret" {
 
 locals {
   managed_annotation_enabled = contains(var.managed_fields, "annotation")
-  managed_label_enabled      = contains(var.managed_fields, "label")
+    managed_label_enabled      = contains(var.managed_fields, "label")
   managed_taint_enabled      = contains(var.managed_fields, "taint")
 }


### PR DESCRIPTION
See https://github.com/xunleii/terraform-module-k3s/pull/33/checks?check_run_id=1027781718

> ReferenceError: self is not defined
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:5277:56), <anonymous>:11:32)
    at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:5278:12)
    at main (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:5303:26)
    at Module.720 (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:5287:1)
    at __webpack_require__ (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:24:31)
    at startup (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:43:19)
    at /home/runner/work/_actions/actions/github-script/v3/dist/index.js:49:18
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/v3/dist/index.js:52:10)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)