### PR TITLE
feat: add dependency endpoint to allow sychronizing k3s install & provisionning

### DIFF
--- a/examples/civo-k3s/.terraform.lock.hcl
+++ b/examples/civo-k3s/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/civo/civo" {
+  version     = "0.9.21"
+  constraints = "0.9.21"
+  hashes = [
+    "h1:ZCHsEq8Qc5hFUJKLsSmeHjXMtCvYzvOJxOLd2aFPzwM=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "1.2.0"
+  constraints = "~> 1.2"
+  hashes = [
+    "h1:g5/qN61yBHRqpGVm08BnBp1O3vVf1eIpMglYvsY13XE=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "2.1.2"
+  constraints = "~> 2.1"
+  hashes = [
+    "h1:CFnENdqQu4g3LJNevA32aDxcUz2qGkRGQpFfkI8TCdE=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "2.3.1"
+  constraints = "~> 2.2"
+  hashes = [
+    "h1:bPBDLMpQzOjKhDlP9uH2UPIz9tSjcbCtLdiJ5ASmCx4=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.0.0"
+  hashes = [
+    "h1:LtCEW5v1E5Eo49+kQOsKHRYf9Hc8ZR0jTpK+mXszPHs=",
+  ]
+}

--- a/examples/hcloud-k3s/.terraform.lock.hcl
+++ b/examples/hcloud-k3s/.terraform.lock.hcl
@@ -1,0 +1,47 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "1.2.0"
+  constraints = "~> 1.2"
+  hashes = [
+    "h1:g5/qN61yBHRqpGVm08BnBp1O3vVf1eIpMglYvsY13XE=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.0.2"
+  hashes = [
+    "h1:PRfDnUFBD4ud7SgsMAa5S2Gd60FeriD1PWE6EifjXB0=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "2.1.2"
+  constraints = "~> 2.1"
+  hashes = [
+    "h1:CFnENdqQu4g3LJNevA32aDxcUz2qGkRGQpFfkI8TCdE=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "2.3.1"
+  constraints = "~> 2.2"
+  hashes = [
+    "h1:bPBDLMpQzOjKhDlP9uH2UPIz9tSjcbCtLdiJ5ASmCx4=",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "3.0.0"
+  hashes = [
+    "h1:LtCEW5v1E5Eo49+kQOsKHRYf9Hc8ZR0jTpK+mXszPHs=",
+  ]
+}
+
+provider "registry.terraform.io/terraform-providers/hcloud" {
+  version = "1.24.1"
+  hashes = [
+    "h1:TEvQLx8GeL3cYf69r4C3zS96QQusHAMuXN1yDeFANs4=",
+  ]
+}

--- a/examples/hcloud-k3s/outputs.tf
+++ b/examples/hcloud-k3s/outputs.tf
@@ -1,3 +1,9 @@
 output "summary" {
   value = module.k3s.summary
 }
+
+output "bootstrap_sa" {
+  description = "Bootstrap ServiceAccount. Can be used by Terraform to provision this cluster."
+  value       = data.kubernetes_secret.sa_credentials.data
+  sensitive   = true
+}

--- a/main.tf
+++ b/main.tf
@@ -9,3 +9,11 @@ locals {
   managed_label_enabled      = contains(var.managed_fields, "label")
   managed_taint_enabled      = contains(var.managed_fields, "taint")
 }
+
+// null_resource used as dependency agregation.
+resource "null_resource" "kubernetes_ready" {
+  depends_on = [
+    null_resource.servers_install, null_resource.servers_annotation, null_resource.servers_label, null_resource.servers_taint,
+    null_resource.agents_install, null_resource.agents_annotation, null_resource.agents_label, null_resource.agents_taint
+  ]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
 output "kubernetes" {
+  description = "Authentication credentials of Kubernetes (full administrator)."
   value = {
     cluster_ca_certificate = local.cluster_ca_certificate
     client_certificate     = local.client_certificate
@@ -11,6 +12,7 @@ output "kubernetes" {
 }
 
 output "kube_config" {
+  description = "Genereated kubeconfig."
   value = var.generate_ca_certificates == false ? null : yamlencode({
     apiVersion = "v1"
     clusters = [{
@@ -41,8 +43,8 @@ output "kube_config" {
   sensitive = true
 }
 
-// Return a "summary" of the current k3s cluster (version & nodes)
 output "summary" {
+  description = "Current state of k3s (version & nodes)."
   value = {
     version : local.k3s_version
     servers : [
@@ -64,4 +66,9 @@ output "summary" {
       }
     ]
   }
+}
+
+output "kubernetes_ready" {
+  description = "Dependency endpoint to synchronize k3s installation and provisioning."
+  value       = null_resource.kubernetes_ready
 }


### PR DESCRIPTION
Add new `kubernetes_ready` which can be used as dependency (`depends_on`) to synchronize installation & provisioning. See `example/hcloud/k3s.tf` for more details.