### PR TITLE
fix: add *_drain to kubernetes_ready

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
 // null_resource used as dependency agregation.
 resource "null_resource" "kubernetes_ready" {
   depends_on = [
-    null_resource.servers_install, null_resource.servers_annotation, null_resource.servers_label, null_resource.servers_taint,
-    null_resource.agents_install, null_resource.agents_annotation, null_resource.agents_label, null_resource.agents_taint
+    null_resource.servers_install, null_resource.servers_drain, null_resource.servers_annotation, null_resource.servers_label, null_resource.servers_taint,
+    null_resource.agents_install, null_resource.agents_drain, null_resource.agents_annotation, null_resource.agents_label, null_resource.agents_taint,
   ]
 }


### PR DESCRIPTION
Because kubernetes_ready will be used as dependency, we need to add `*_drain` resources to avoid draining nodes before removing resources which depends on it.