### PR TITLE
Add support for provisioning without logging in as root

### DIFF
--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -164,8 +164,10 @@ resource "null_resource" "agents_drain" {
   }
 
   provisioner "remote-exec" {
-    when   = destroy
-    inline = ["kubectl drain ${self.triggers.agent_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"]
+    when = destroy
+    inline = [
+      "kubectl drain ${self.triggers.agent_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
+    ]
   }
 }
 
@@ -219,13 +221,15 @@ resource "null_resource" "agents_annotation" {
   provisioner "remote-exec" {
     inline = [
       "until kubectl get node ${self.triggers.agent_name}; do sleep 1; done",
-    "kubectl annotate --overwrite node ${self.triggers.agent_name} ${self.triggers.annotation_name}=${self.triggers.on_value_changes}"]
+      "kubectl annotate --overwrite node ${self.triggers.agent_name} ${self.triggers.annotation_name}=${self.triggers.on_value_changes}"
+    ]
   }
 
   provisioner "remote-exec" {
     when = destroy
     inline = [
-    "kubectl annotate node ${self.triggers.agent_name} ${self.triggers.annotation_name}-"]
+      "kubectl annotate node ${self.triggers.agent_name} ${self.triggers.annotation_name}-"
+    ]
   }
 }
 
@@ -279,13 +283,15 @@ resource "null_resource" "agents_label" {
   provisioner "remote-exec" {
     inline = [
       "until kubectl get node ${self.triggers.agent_name}; do sleep 1; done",
-    "kubectl label --overwrite node ${self.triggers.agent_name} ${self.triggers.label_name}=${self.triggers.on_value_changes}"]
+      "kubectl label --overwrite node ${self.triggers.agent_name} ${self.triggers.label_name}=${self.triggers.on_value_changes}"
+    ]
   }
 
   provisioner "remote-exec" {
     when = destroy
     inline = [
-    "kubectl label node ${self.triggers.agent_name} ${self.triggers.label_name}-"]
+      "kubectl label node ${self.triggers.agent_name} ${self.triggers.label_name}-"
+    ]
   }
 }
 
@@ -339,11 +345,14 @@ resource "null_resource" "agents_taint" {
   provisioner "remote-exec" {
     inline = [
       "until kubectl get node ${self.triggers.agent_name}; do sleep 1; done",
-    "kubectl taint node ${self.triggers.agent_name} ${self.triggers.taint_name}=${self.triggers.on_value_changes} --overwrite"]
+      "kubectl taint node ${self.triggers.agent_name} ${self.triggers.taint_name}=${self.triggers.on_value_changes} --overwrite"
+    ]
   }
 
   provisioner "remote-exec" {
-    when   = destroy
-    inline = ["kubectl taint node ${self.triggers.agent_name} ${self.triggers.taint_name}-"]
+    when = destroy
+    inline = [
+      "kubectl taint node ${self.triggers.agent_name} ${self.triggers.taint_name}-"
+    ]
   }
 }

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -143,12 +143,10 @@ resource "null_resource" "k8s_ca_certificates_install" {
   }
 
   provisioner "remote-exec" {
-    inline = ["mkdir -p /var/lib/rancher/k3s/server/tls/"]
-  }
-
-  provisioner "file" {
-    content     = local.certificates_files[count.index].file_content
-    destination = "/var/lib/rancher/k3s/server/tls/${local.certificates_files[count.index].file_name}"
+    inline = [
+      "sudo mkdir -p /var/lib/rancher/k3s/server/tls/",
+      "echo '${local.certificates_files[count.index].file_content}' | sudo tee /var/lib/rancher/k3s/server/tls/${local.certificates_files[count.index].file_name} > /dev/null"
+    ]
   }
 }
 
@@ -249,8 +247,10 @@ resource "null_resource" "servers_drain" {
   }
 
   provisioner "remote-exec" {
-    when   = destroy
-    inline = ["kubectl drain ${self.triggers.server_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"]
+    when = destroy
+    inline = [
+      "kubectl drain ${self.triggers.server_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
+    ]
   }
 }
 
@@ -300,13 +300,15 @@ resource "null_resource" "servers_annotation" {
 
   provisioner "remote-exec" {
     inline = [
-    "kubectl annotate --overwrite node ${self.triggers.server_name} ${self.triggers.annotation_name}=${self.triggers.on_value_changes}"]
+      "kubectl annotate --overwrite node ${self.triggers.server_name} ${self.triggers.annotation_name}=${self.triggers.on_value_changes}"
+    ]
   }
 
   provisioner "remote-exec" {
     when = destroy
     inline = [
-    "kubectl annotate node ${self.triggers.server_name} ${self.triggers.annotation_name}-"]
+      "kubectl annotate node ${self.triggers.server_name} ${self.triggers.annotation_name}-"
+    ]
   }
 }
 
@@ -356,13 +358,15 @@ resource "null_resource" "servers_label" {
 
   provisioner "remote-exec" {
     inline = [
-    "kubectl label --overwrite node ${self.triggers.server_name} ${self.triggers.label_name}=${self.triggers.on_value_changes}"]
+      "kubectl label --overwrite node ${self.triggers.server_name} ${self.triggers.label_name}=${self.triggers.on_value_changes}"
+    ]
   }
 
   provisioner "remote-exec" {
     when = destroy
     inline = [
-    "kubectl label node ${self.triggers.server_name} ${self.triggers.label_name}-"]
+      "kubectl label node ${self.triggers.server_name} ${self.triggers.label_name}-"
+    ]
   }
 }
 
@@ -413,12 +417,14 @@ resource "null_resource" "servers_taint" {
 
   provisioner "remote-exec" {
     inline = [
-    "kubectl taint node ${self.triggers.server_name} ${self.triggers.taint_name}=${self.triggers.on_value_changes} --overwrite"]
+      "kubectl taint node ${self.triggers.server_name} ${self.triggers.taint_name}=${self.triggers.on_value_changes} --overwrite"
+    ]
   }
 
   provisioner "remote-exec" {
     when = destroy
     inline = [
-    "kubectl taint node ${self.triggers.server_name} ${self.triggers.taint_name}-"]
+      "kubectl taint node ${self.triggers.server_name} ${self.triggers.taint_name}-"
+    ]
   }
 }

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -144,8 +144,13 @@ resource "null_resource" "k8s_ca_certificates_install" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mkdir -p /var/lib/rancher/k3s/server/tls/",
-      "echo '${local.certificates_files[count.index].file_content}' | sudo tee /var/lib/rancher/k3s/server/tls/${local.certificates_files[count.index].file_name} > /dev/null"
+      <<-EOT
+      # --- use sudo if we are not already root ---
+      [ $(id -u) -eq 0 ] || exec sudo -n $0 $@
+
+      mkdir -p /var/lib/rancher/k3s/server/tls/
+      echo '${local.certificates_files[count.index].file_content}' > /var/lib/rancher/k3s/server/tls/${local.certificates_files[count.index].file_name}
+      EOT
     ]
   }
 }


### PR DESCRIPTION
The k8s_ca_certificates_install provisioner now uses sudo to create the certificate. This enables a non-root user (with sudo permissions) to create this resource.

In addition to this change, a non-root user must set the following server flags to make the kube config file world readable:

`flags = ["--write-kubeconfig-mode '0644'"]`

This assumes that the non-root user can sudo with no password.

Relates to: https://github.com/xunleii/terraform-module-k3s/issues/42