### PR TITLE
add option to use kubectl with sudo

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -146,3 +146,9 @@ variable "separator" {
   description = "Separator used to separates node name and field name (used to manage annotations, labels and taints)."
   default     = "|"
 }
+
+variable "use_sudo" {
+  description = "Whether or not to use kubectl with sudo during cluster setup."
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
It's useful when using user other than root to be able to use sudo to run kubectl, especially on operating systems that do not allow root login from ssh.

The default behavior does not change as the default value for the new variable is "false" and thus the default command to invoke kubectl does not change either.