### PR TITLE
Output the Kubernetes cluster secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,13 @@ module "k3s" {
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_kube_config"></a> [kube\_config](#output\_kube\_config) | Genereated kubeconfig. |
-| <a name="output_kubernetes"></a> [kubernetes](#output\_kubernetes) | Authentication credentials of Kubernetes (full administrator). |
-| <a name="output_kubernetes_ready"></a> [kubernetes\_ready](#output\_kubernetes\_ready) | Dependency endpoint to synchronize k3s installation and provisioning. |
-| <a name="output_summary"></a> [summary](#output\_summary) | Current state of k3s (version & nodes). |
+| Name                                                                                               | Description |
+|----------------------------------------------------------------------------------------------------|-------------|
+| <a name="output_kube_config"></a> [kube\_config](#output\_kube\_config)                            | Genereated kubeconfig. |
+| <a name="output_kubernetes"></a> [kubernetes](#output\_kubernetes)                                 | Authentication credentials of Kubernetes (full administrator). |
+| <a name="output_kubernetes_ready"></a> [kubernetes\_ready](#output\_kubernetes\_ready)             | Dependency endpoint to synchronize k3s installation and provisioning. |
+| <a name="output_summary"></a> [summary](#output\_summary)                                          | Current state of k3s (version & nodes). |
+| <a name="kubernetes_cluster_secret"></a> [kubernetes_cluster_secret](#kubernetes\_cluster\_secret) | Secret token used to join nodes to the cluster |
 
 ## Requirements
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -76,5 +76,5 @@ output "kubernetes_ready" {
 output "kubernetes_cluster_secret" {
   description = "Secret token used to join nodes to the cluster"
   value       = random_password.k3s_cluster_secret.result
-  sensitive = true
+  sensitive   = true
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -72,3 +72,8 @@ output "kubernetes_ready" {
   description = "Dependency endpoint to synchronize k3s installation and provisioning."
   value       = null_resource.kubernetes_ready
 }
+
+output "kubernetes_cluster_secret" {
+  description = "Secret token used to join nodes to the cluster"
+  value       = random_password.k3s_cluster_secret.result
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -76,4 +76,5 @@ output "kubernetes_ready" {
 output "kubernetes_cluster_secret" {
   description = "Secret token used to join nodes to the cluster"
   value       = random_password.k3s_cluster_secret.result
+  sensitive = true
 }


### PR DESCRIPTION
Sometimes it is quite useful to have access to the cluster secret programmatically. We may want to provision nodes with this module, but also join others manually.

This PR adds a `kubernetes_cluster_secret` output for this use case.