### PR TITLE
Update providers and fix #110

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,75 +2,81 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/http" {
-  version     = "3.1.0"
+  version     = "3.2.1"
   constraints = "~> 3.0"
   hashes = [
-    "h1:0QHdTeDcRFKD4YybtVl1F95/qo8n4DY5fANQVYBvt10=",
-    "h1:4HdKAc5Hc0kYotKBd5PxgbbJmKuCkuEBZzAZfjm5I8I=",
-    "h1:B6Ic31cYk12cdynH2EDlIkgFOd93qouIGK85OyRLXx8=",
-    "h1:CSZP7J4tVA0r4WH/xkWno33GqLKS0je+7LvjGJJgd8U=",
-    "h1:FdEkmfqoUBXvpMbauSJlHTKwHBC2HL7x82dRaRdmZBA=",
-    "h1:PMN7NpxfRK5UDvKEUovdtRJZQS6b9CsvEixQ/Xbc+qw=",
-    "h1:Uxjkgg79PUalHTiSDf7ALuFz9OWlvQmZTFYOcb9zSOI=",
-    "h1:WXQQJa2AKCAQdzkonw9JsrOfVHATSQ/pAz1eJSn6z2c=",
-    "h1:fmokxOn/hzBi7EGkOWgjDc+nK5rxQFf/rzL0T14SUms=",
-    "h1:q6Iu272CbLvzrE8DE2ObmppmxKvT3ZvBxVBS0w1zs9E=",
-    "h1:tj1w5q1szPvYxaK0Aneyd/ISHRfmSbwIE3pFYLxgIAk=",
+    "h1:DfxMa1zM/0NCFWN5PAxivSHJMNkOAFZvDYQkO72ZQmw=",
+    "zh:088b3b3128034485e11dff8da16e857d316fbefeaaf5bef24cceda34c6980641",
+    "zh:09ed1f2462ea4590b112e048c4af556f0b6eafc7cf2c75bb2ac21cd87ca59377",
+    "zh:39c6b0b4d3f0f65e783c467d3f634e2394820b8aef907fcc24493f21dcf73ca3",
+    "zh:47aab45327daecd33158a36c1a36004180a518bf1620cdd5cfc5e1fe77d5a86f",
+    "zh:4d70a990aa48116ab6f194eef393082c21cf58bece933b63575c63c1d2b66818",
+    "zh:65470c43fda950c7e9ac89417303c470146de984201fff6ef84299ea29e02d30",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:842b4dd63e438f5cd5fdfba1c09b8fdf268e8766e6690988ee24e8b25bfd9e8d",
+    "zh:a167a057f7e2d80c78d4b4057538588131fceb983d5c93b07675ad9eb1aa5790",
+    "zh:d0ba69b62b6db788cfe3cf8f7dc6e9a0eabe2927dc119d7fe3fe6573ee559e66",
+    "zh:e28d24c1d5ff24b1d1cc6f0074a1f41a6974f473f4ff7a37e55c7b6dca68308a",
+    "zh:fde8a50554960e5366fd0e1ca330a7c1d24ae6bbb2888137a5c83d83ce14fd18",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.1.0"
+  version     = "3.2.1"
   constraints = "~> 3.0"
   hashes = [
-    "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
-    "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
-    "zh:53e30545ff8926a8e30ad30648991ca8b93b6fa496272cd23b26763c8ee84515",
-    "zh:5f9200bf708913621d0f6514179d89700e9aa3097c77dac730e8ba6e5901d521",
-    "zh:9ebf4d9704faba06b3ec7242c773c0fbfe12d62db7d00356d4f55385fc69bfb2",
-    "zh:a6576c81adc70326e4e1c999c04ad9ca37113a6e925aefab4765e5a5198efa7e",
-    "zh:a8a42d13346347aff6c63a37cda9b2c6aa5cc384a55b2fe6d6adfa390e609c53",
-    "zh:c797744d08a5307d50210e0454f91ca4d1c7621c68740441cf4579390452321d",
-    "zh:cecb6a304046df34c11229f20a80b24b1603960b794d68361a67c5efe58e62b8",
-    "zh:e1371aa1e502000d9974cfaff5be4cfa02f47b17400005a16f14d2ef30dc2a70",
-    "zh:fc39cc1fe71234a0b0369d5c5c7f876c71b956d23d7d6f518289737a001ba69b",
-    "zh:fea4227271ebf7d9e2b61b89ce2328c7262acd9fd190e1fd6d15a591abfa848e",
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.1.0"
+  version     = "3.4.3"
   constraints = "~> 3.0"
   hashes = [
-    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
-    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
-    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
-    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
-    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
-    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
-    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
-    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
-    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
-    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
-    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
-    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+    "h1:xZGZf18JjMS06pFa4NErzANI98qi59SEcBsOcS2P2yQ=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/tls" {
-  version     = "4.0.3"
+  version     = "4.0.4"
   constraints = "~> 4.0"
   hashes = [
-    "h1:6eMhGbfXksn7n9cRMFRKYZhPt/V/RLMVR3OPeAUzIMA=",
-    "h1:6xdy3HsRO4zTiS9mSZfsh//hO1u+h+25LRpphmo1eyI=",
-    "h1:7hgDWpJ5gi65QYEzJ95zkNtJYdTwsPfQ5CXEvCGAB1Q=",
-    "h1:GmZU66AMQbs93Rry4ylyersEqg4Nc1TJgSXfKdycmCs=",
-    "h1:TtxH+PuCVPoWUpkMhjdz4QB1i7A4/Ag9kIouPabKDrI=",
-    "h1:Y+Ro2qtApW0Qp4//mTBNVf2I/flNvahpjKpGB7U0YTs=",
-    "h1:dt+GmKJBmGHPlkFBTFxdd676j03g1qeuGqgX5/YkLqs=",
-    "h1:dzEm5UF25Ef1pDJRtw2yB+wTJo3eND2RVEts7dg4CAE=",
-    "h1:i4JPrh7pR4GllH0MSLS7fRACsVcfJIDBQyNHk50XB5U=",
-    "h1:oVF7wWUxQjEJD8EEg6DW7+JkOPGmvc7eJ3ylKbG8xmY=",
-    "h1:r+5I08cum0iMcWp+ILHoacJ896BhEEk6vkhDrAT8ifU=",
+    "h1:pe9vq86dZZKCm+8k1RhzARwENslF3SXb9ErHbQfgjXU=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -106,7 +106,7 @@ resource "null_resource" "agents_install" {
 
   // Upload k3s install script
   provisioner "file" {
-    content     = data.http.k3s_installer.body
+    content     = data.http.k3s_installer.response_body
     destination = "/tmp/k3s-installer"
   }
 

--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -35,7 +35,7 @@ locals {
   ])
   agent_taints = local.managed_taint_enabled ? { for o in local.agent_taints_list : o.key => o.value if o.key != "" } : {}
 
-  // Generate a map of all calculed agent fields, used during k3s installation.
+  // Generate a map of all calculated agent fields, used during k3s installation.
   agents_metadata = {
     for key, agent in var.agents :
     key => {

--- a/examples/hcloud-k3s/k3s.tf
+++ b/examples/hcloud-k3s/k3s.tf
@@ -21,7 +21,8 @@ module "k3s" {
     hcloud_server.control_planes[i].name => {
       ip = hcloud_server_network.control_planes[i].ip
       connection = {
-        host = hcloud_server.control_planes[i].ipv4_address
+        host        = hcloud_server.control_planes[i].ipv4_address
+        private_key = trimspace(tls_private_key.ed25519-provisioning.private_key_pem)
       }
       flags       = ["--disable-cloud-controller"]
       annotations = { "server_id" : i } // theses annotations will not be managed by this module
@@ -34,54 +35,12 @@ module "k3s" {
       name = hcloud_server.agents[i].name
       ip   = hcloud_server_network.agents_network[i].ip
       connection = {
-        host = hcloud_server.agents[i].ipv4_address
+        host        = hcloud_server.agents[i].ipv4_address
+        private_key = trimspace(tls_private_key.ed25519-provisioning.private_key_pem)
       }
 
       labels = { "node.kubernetes.io/pool" = hcloud_server.agents[i].labels.nodepool }
       taints = { "dedicated" : hcloud_server.agents[i].labels.nodepool == "gpu" ? "gpu:NoSchedule" : null }
     }
-  }
-}
-
-provider "kubernetes" {
-  host                   = module.k3s.kubernetes.api_endpoint
-  cluster_ca_certificate = module.k3s.kubernetes.cluster_ca_certificate
-  client_certificate     = module.k3s.kubernetes.client_certificate
-  client_key             = module.k3s.kubernetes.client_key
-}
-
-resource "kubernetes_service_account" "bootstrap" {
-  depends_on = [module.k3s.kubernetes_ready]
-
-  metadata {
-    name      = "bootstrap"
-    namespace = "default"
-  }
-}
-
-resource "kubernetes_cluster_role_binding" "boostrap" {
-  depends_on = [module.k3s.kubernetes_ready]
-
-  metadata {
-    name = "bootstrap"
-  }
-
-  subject {
-    kind      = "ServiceAccount"
-    name      = "bootstrap"
-    namespace = "default"
-  }
-
-  role_ref {
-    api_group = "rbac.authorization.k8s.io"
-    kind      = "ClusterRole"
-    name      = "admin"
-  }
-}
-
-data "kubernetes_secret" "sa_credentials" {
-  metadata {
-    name      = kubernetes_service_account.bootstrap.default_secret_name
-    namespace = "default"
   }
 }

--- a/examples/hcloud-k3s/main.tf
+++ b/examples/hcloud-k3s/main.tf
@@ -1,8 +1,16 @@
 provider "hcloud" {}
 
+data "hcloud_image" "ubuntu" {
+  name = "ubuntu-20.04"
+}
+
+resource "tls_private_key" "ed25519-provisioning" {
+  algorithm = "ED25519"
+}
+
 resource "hcloud_ssh_key" "default" {
   name       = "K3S terraform module - Provisionning SSH key"
-  public_key = var.ssh_key
+  public_key = trimspace(tls_private_key.ed25519-provisioning.public_key_openssh)
 }
 
 resource "hcloud_network" "k3s" {
@@ -15,8 +23,4 @@ resource "hcloud_network_subnet" "k3s_nodes" {
   network_id   = hcloud_network.k3s.id
   network_zone = "eu-central"
   ip_range     = "10.254.1.0/24"
-}
-
-data "hcloud_image" "ubuntu" {
-  name = "ubuntu-20.04"
 }

--- a/examples/hcloud-k3s/outputs.tf
+++ b/examples/hcloud-k3s/outputs.tf
@@ -2,8 +2,8 @@ output "summary" {
   value = module.k3s.summary
 }
 
-output "bootstrap_sa" {
-  description = "Bootstrap ServiceAccount. Can be used by Terraform to provision this cluster."
-  value       = data.kubernetes_secret.sa_credentials.data
+output "ssh_private_key" {
+  description = "Generated SSH private key."
+  value       = tls_private_key.ed25519-provisioning.private_key_openssh
   sensitive   = true
 }

--- a/examples/hcloud-k3s/variables.tf
+++ b/examples/hcloud-k3s/variables.tf
@@ -1,8 +1,3 @@
-variable "ssh_key" {
-  description = "SSH public Key content needed to provision the instances."
-  type        = string
-}
-
 variable "servers_num" {
   description = "Number of control plane nodes."
   default     = 3

--- a/k3s_version.tf
+++ b/k3s_version.tf
@@ -5,10 +5,10 @@ data "http" "k3s_version" {
 
 // Fetch the k3s installation script
 data "http" "k3s_installer" {
-  url = "https://raw.githubusercontent.com/rancher/k3s/${jsondecode(data.http.k3s_version.body).data[1].latest}/install.sh"
+  url = "https://raw.githubusercontent.com/rancher/k3s/${jsondecode(data.http.k3s_version.response_body).data[1].latest}/install.sh"
 }
 
 locals {
   // Use the fetched version if 'lastest' is specified
-  k3s_version = var.k3s_version == "latest" ? jsondecode(data.http.k3s_version.body).data[1].latest : var.k3s_version
+  k3s_version = var.k3s_version == "latest" ? jsondecode(data.http.k3s_version.response_body).data[1].latest : var.k3s_version
 }

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -75,7 +75,7 @@ locals {
   ])
   server_taints = local.managed_taint_enabled ? { for o in local.server_taints_list : o.key => o.value if o.key != "" } : {}
 
-  // Generate a map of all calculed server fields, used during k3s installation.
+  // Generate a map of all calculated server fields, used during k3s installation.
   servers_metadata = {
     for key, server in var.servers :
     key => {

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -206,7 +206,7 @@ resource "null_resource" "servers_install" {
 
   // Upload k3s file
   provisioner "file" {
-    content     = data.http.k3s_installer.body
+    content     = data.http.k3s_installer.response_body
     destination = "/tmp/k3s-installer"
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -17,5 +17,6 @@ terraform {
       version = "~> 4.0"
     }
   }
+
   required_version = "~> 1.0"
 }


### PR DESCRIPTION
In this PR:
- Update all providers
- Fix some typos inside comments
- Update hetzner example (remove Kubernetes SA génération and mange SSH private key internally) (fix #110)
- Use `response_body` instead of `body` (deprecated)