### PR TITLE
Dual-stack & IPv6 fixes

### DIFF
--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -46,7 +46,7 @@ locals {
         [
           "--node-ip ${agent.ip}",
           "--node-name '${try(agent.name, key)}'",
-          "--server https://${local.root_server_ip}:6443",
+          "--server https://${local.root_advertise_ip}:6443",
           "--token ${random_password.k3s_cluster_secret.result}",
         ],
         var.global_flags,

--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -46,7 +46,7 @@ locals {
         [
           "--node-ip ${agent.ip}",
           "--node-name '${try(agent.name, key)}'",
-          "--server https://${local.root_advertise_ip_curl}:6443",
+          "--server https://${local.root_advertise_ip_k3s}:6443",
           "--token ${random_password.k3s_cluster_secret.result}",
         ],
         var.global_flags,

--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -46,7 +46,7 @@ locals {
         [
           "--node-ip ${agent.ip}",
           "--node-name '${try(agent.name, key)}'",
-          "--server https://${local.root_advertise_ip}:6443",
+          "--server https://${local.root_advertise_ip_curl}:6443",
           "--token ${random_password.k3s_cluster_secret.result}",
         ],
         var.global_flags,

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -93,7 +93,7 @@ locals {
         [
           "--node-ip ${server.ip}",
           "--node-name '${try(server.name, key)}'",
-          "--server https://${local.root_server_ip}:6443",
+          "--server https://${local.root_advertise_ip}:6443",
           "--cluster-cidr ${var.cidr.pods}",
           "--service-cidr ${var.cidr.services}",
           "--token ${random_password.k3s_cluster_secret.result}",

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -3,16 +3,10 @@ locals {
   root_server_name = keys(var.servers)[0]
 
   // Get the first address from the IP array using comma's as the delimiter
-  root_advertise_addr = [split(",", values(var.servers)[0].ip)[0]]
-  
-  // Look at root_advertise_addr and see if it contains '::' to figure out if it is an IPv4 or IPv6 address
-  root_advertise_ipv4 = [for addr in local.root_advertise_addr : addr if !can(regex("::", addr))]
-  root_advertise_ipv6 = [for addr in local.root_advertise_addr : addr if can(regex("::", addr))]
-  
-  // If root_advertise_ipv4 is not empty, use it, else use root_advertise_ipv6
-  root_advertise_ip = length(local.root_advertise_ipv4) > 0 ? local.root_advertise_ipv4[0] : "${local.root_advertise_ipv6[0]}"
-  // If root_advertise_ipv4 is not empty, use it, else use root_advertise_ipv6 and wrap it in square brackets for IPv6 K3S URLs
-  root_advertise_ip_curl = length(local.root_advertise_ipv4) > 0 ? local.root_advertise_ipv4[0] : "[${local.root_advertise_ipv6[0]}]"
+	root_advertise_ip = split(",", values(var.servers)[0].ip)[0]
+	
+	// If root_advertise_ip is IPv6 wrap it in square brackets for IPv6 K3S URLs otherwise leave it raw
+	root_advertise_ip_k3s = can(regex("::", local.root_advertise_ip)) ? "[${local.root_advertise_ip}]" : local.root_advertise_ip
 
 
   root_server_ip = values(var.servers)[0].ip

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -99,7 +99,7 @@ locals {
         [
           "--node-ip ${server.ip}",
           "--node-name '${try(server.name, key)}'",
-          "--server https://${local.root_advertise_ip_curl}:6443",
+          "--server https://${local.root_advertise_ip_k3s}:6443",
           "--cluster-cidr ${var.cidr.pods}",
           "--service-cidr ${var.cidr.services}",
           "--token ${random_password.k3s_cluster_secret.result}",

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -1,7 +1,7 @@
 locals {
   // Some vars use to easily access to the first k3s server values
   root_server_name = keys(var.servers)[0]
-  root_server_ip   = values(var.servers)[0].ip
+  root_server_ip   = split(",", values(var.servers)[0].ip)[0]
   root_server_connection = {
     type = try(var.servers[local.root_server_name].connection.type, "ssh")
 

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -1,8 +1,18 @@
 locals {
   // Some vars use to easily access to the first k3s server values
   root_server_name = keys(var.servers)[0]
-  root_advertise_ip   = split(",", values(var.servers)[0].ip)[0]
-  root_server_ip   = values(var.servers)[0].ip
+
+  // Get the first address from the IP array using comma's as the delimiter
+  root_advertise_addr = split(",", values(var.servers)[0].ip)[0]
+  
+  // Look at root_advertise_addr and see if it contains '::' to figure out if it is an IPv4 or IPv6 address
+  root_advertise_ipv4 = [for addr in local.root_advertise_addr : addr if !can(regex("::", addr))]
+  root_advertise_ipv6 = [for addr in local.root_advertise_addr : addr if can(regex("::", addr))]
+  
+  // If root_advertise_ipv4 is not empty, use it, else use root_advertise_ipv6 and add square brackets to prevent k3s breaking
+  root_advertise_ip = length(local.root_advertise_ipv4) > 0 ? local.root_advertise_ipv4[0] : "[${local.root_advertise_ipv6[0]}]"
+
+  root_server_ip = values(var.servers)[0].ip
   root_server_connection = {
     type = try(var.servers[local.root_server_name].connection.type, "ssh")
 

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -9,7 +9,6 @@ locals {
 	root_advertise_ip_k3s = can(regex("::", local.root_advertise_ip)) ? "[${local.root_advertise_ip}]" : local.root_advertise_ip
 
 
-  root_server_ip = values(var.servers)[0].ip
   root_server_connection = {
     type = try(var.servers[local.root_server_name].connection.type, "ssh")
 

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -1,7 +1,8 @@
 locals {
   // Some vars use to easily access to the first k3s server values
   root_server_name = keys(var.servers)[0]
-  root_server_ip   = split(",", values(var.servers)[0].ip)[0]
+  root_advertise_ip   = split(",", values(var.servers)[0].ip)[0]
+  root_server_ip   = values(var.servers)[0].ip
   root_server_connection = {
     type = try(var.servers[local.root_server_name].connection.type, "ssh")
 
@@ -79,7 +80,7 @@ locals {
         key == local.root_server_name ?
         // For the first server node, add all configuration flags
         [
-          "--advertise-address ${local.root_server_ip}",
+          "--advertise-address ${local.root_advertise_ip}",
           "--node-ip ${server.ip}",
           "--node-name '${try(server.name, key)}'",
           "--cluster-domain '${var.cluster_domain}'",

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -79,6 +79,7 @@ locals {
         key == local.root_server_name ?
         // For the first server node, add all configuration flags
         [
+          "--advertise-address ${local.root_server_ip}",
           "--node-ip ${server.ip}",
           "--node-name '${try(server.name, key)}'",
           "--cluster-domain '${var.cluster_domain}'",

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -3,10 +3,10 @@ locals {
   root_server_name = keys(var.servers)[0]
 
   // Get the first address from the IP array using comma's as the delimiter
-	root_advertise_ip = split(",", values(var.servers)[0].ip)[0]
-	
-	// If root_advertise_ip is IPv6 wrap it in square brackets for IPv6 K3S URLs otherwise leave it raw
-	root_advertise_ip_k3s = can(regex("::", local.root_advertise_ip)) ? "[${local.root_advertise_ip}]" : local.root_advertise_ip
+  root_advertise_ip = split(",", values(var.servers)[0].ip)[0]
+
+  // If root_advertise_ip is IPv6 wrap it in square brackets for IPv6 K3S URLs otherwise leave it raw
+  root_advertise_ip_k3s = can(regex("::", local.root_advertise_ip)) ? "[${local.root_advertise_ip}]" : local.root_advertise_ip
 
 
   root_server_connection = {


### PR DESCRIPTION
Fixes for issue #111 

### Changes:

- Get the first master server address from IP array. Set as `${local.root_advertise_addr}` variable.
[commit 15b8d2c](https://github.com/xunleii/terraform-module-k3s/commit/15b8d2cf9dedc9226dd50d4ef28d188fc6e5c3aa)
[commit 4f93fb5](https://github.com/xunleii/terraform-module-k3s/commit/4f93fb54a076c7a2f713187ba59d90e4f1e58feb)

- Determine if address is IPv4 or IPv6. If address is IPv6 surround address in square brackets to stop k3s breaking. Set result as `${local.root_advertise_ip}` variable.
[commit 611711d](https://github.com/xunleii/terraform-module-k3s/commit/611711d740f84604571fa0023e65acc9eec50edc)
[commit 3884844](https://github.com/xunleii/terraform-module-k3s/commit/3884844f279ebfbfd8dedfcf5c17dda9936c93e0)

- Add `--advertise-address` flag to primary master server using `${local.root_advertise_ip}` variable.
[commit ad21b0b](https://github.com/xunleii/terraform-module-k3s/commit/ad21b0b4c6b43c01eb3ebf3d5dce01cbc08fa9dd)

- Add `${root_advertise_ip}` variable to server and agent install templates.
[commit 752fe16](https://github.com/xunleii/terraform-module-k3s/commit/752fe16b6a53292ea21c7d53636d30dae6ecbdd5)

_***Please Note:***_ K3S requires your entire cluster must be **_one_** of either:
  - IPv4 only
  - IPv6 only
  - Dual Stack.
You can not mix modes.

### Tested and confirmed working with:
 - [x] Single Stack IPv4
 - [x] Single Stack IPv6
 - [x] Dual Stack IPv4/IPv6