### PR TITLE
feat(lb): support specifiying an external loadbalancer

### DIFF
--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -35,6 +35,7 @@ locals {
   ])
   agent_taints = local.managed_taint_enabled ? { for o in local.agent_taints_list : o.key => o.value if o.key != "" } : {}
 
+
   // Generate a map of all calculated agent fields, used during k3s installation.
   agents_metadata = {
     for key, agent in var.agents :

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,7 +18,7 @@ output "kube_config" {
     clusters = [{
       cluster = {
         certificate-authority-data = base64encode(local.cluster_ca_certificate)
-        server                     = "https://${local.root_server_connection.host}:6443"
+        server                     = "https://${local.root_advertise_ip}:6443"
       }
       name = var.cluster_domain
     }]

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -3,7 +3,7 @@ locals {
   root_server_name = keys(var.servers)[0]
 
   // Get the first address from the IP array using comma's as the delimiter
-  root_advertise_ip = split(",", values(var.servers)[0].ip)[0]
+  root_advertise_ip = coalesce(var.loadbalancer_address, split(",", values(var.servers)[0].ip)[0])
 
   // If root_advertise_ip is IPv6 wrap it in square brackets for IPv6 K3S URLs otherwise leave it raw
   root_advertise_ip_k3s = can(regex("::", local.root_advertise_ip)) ? "[${local.root_advertise_ip}]" : local.root_advertise_ip

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "cluster_domain" {
   default     = "cluster.local"
 }
 
+variable "loadbalancer_address" {
+  description = "IP or DNS of an external loadbalancer that is used as an advertise address for server and as the k3s server url for agents. If null (default) the first server address is used"
+  type        = string
+  default     = null
+}
+
 variable "generate_ca_certificates" {
   description = "If true, this module will generate the CA certificates (see https://github.com/rancher/k3s/issues/1868#issuecomment-639690634). Otherwise rancher will generate it. This is required to generate kubeconfig"
   type        = bool


### PR DESCRIPTION
Bonjour my friend,

this is a bit tricky but maybe we can find a way to support this use case.

I am setting up an k3s HA cluster (3 server, 3 agents) and want to have an external LB for the control plane and the agent nodes.

In my understanding this can be archived specifying the `--advertise-address` flag for server and the `--server` flag for agents. Hence I introduced a new variable `loadbalancer_address` that if specified (default null) is used for that purpose.

Does that make sense for you?