### PR TITLE
Fix k3s_install_env_vars and hcloud-k3s example issues

### DIFF
--- a/examples/hcloud-k3s/main.tf
+++ b/examples/hcloud-k3s/main.tf
@@ -1,5 +1,3 @@
-provider "hcloud" {}
-
 data "hcloud_image" "ubuntu" {
   name = "ubuntu-20.04"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "k3s_version" {
 variable "k3s_install_env_vars" {
   description = "map of enviroment variables that are passed to the k3s installation script (see https://docs.k3s.io/reference/env-variables)"
   type        = map(string)
-  default     = null
+  default     = {}
 
   validation {
     condition     = !can(var.k3s_install_env_vars["INSTALL_K3S_VERSION"])


### PR DESCRIPTION
- Remove empty provisioner block
- Add empty map for k3s_install_env_vars by default

fix #127 