### PR TITLE
fix--multi_server-install

### DIFF
--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -102,6 +102,7 @@ locals {
           "--node-ip ${server.ip}",
           "--node-name '${try(server.name, key)}'",
           "--server https://${local.root_advertise_ip_k3s}:6443",
+          "--cluster-domain '${var.cluster_domain}'",
           "--cluster-cidr ${var.cidr.pods}",
           "--service-cidr ${var.cidr.services}",
           "--token ${random_password.k3s_cluster_secret.result}",


### PR DESCRIPTION
In order for the second, third, etc server to join the cluster, the cluster domain needs to be the same on all the nodes. This update ensures that.