### PR TITLE
let k8s_ca_certificates_install depend on var.depends_on_

### DIFF
--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -125,6 +125,8 @@ locals {
 resource "null_resource" "k8s_ca_certificates_install" {
   count = length(local.certificates_files)
 
+  depends_on = [var.depends_on_]
+
   connection {
     type = try(local.root_server_connection.type, "ssh")
 


### PR DESCRIPTION
Hi, thanks for providing this module.

I think this line is missing unintentionally. Without the change I get the following error:
```
│ Error: remote-exec provisioner error
│ 
│   with module.k3s.null_resource.k8s_ca_certificates_install[4],
│   on .terraform/modules/k3s/server_nodes.tf line 158, in resource "null_resource" "k8s_ca_certificates_install":
│  158:   provisioner "remote-exec" {
│ 
│ timeout - last error: SSH authentication failed (core@[...ipv4...]:22): ssh: handshake failed: ssh: unable to authenticate, attempted methods [none
│ publickey], no supported methods remain
```

The context is a single node on hcloud (Hetzner) booted to rescue system, Flatcar Linux installation through calling their install script, k3s installation through your module (and finally a fluxCD installation).

I _think_ the issue is that authenticating to the different install steps requires different credentials and this one step tries to authenticate too early, which fails. Waiting for the correct - later - install step allows authentication.

As far as I can tell, this change does not have any negative impact, so I didn't investigate the exact reason / issue. If you need any further information (e.g. minimal example), I'd be happy to help.
