### PR TITLE
reevaluate path every try during servers install

### DIFF
--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -217,7 +217,7 @@ resource "null_resource" "servers_install" {
   provisioner "remote-exec" {
     inline = [
       "${local.install_env_vars} INSTALL_K3S_VERSION=${local.k3s_version} sh /tmp/k3s-installer server ${local.servers_metadata[each.key].flags}",
-      "until ${local.kubectl_cmd} get node ${local.servers_metadata[each.key].name}; do sleep 1; done"
+      "until sh -c '${local.kubectl_cmd} get node ${local.servers_metadata[each.key].name}'; do sleep 1; done"
     ]
   }
 }


### PR DESCRIPTION
On flatcar Linux, the kubectl binary is installed to /opt/bin/kubectl, which apparently is not in PATH at time of script start.

Previously, it produced: module.k3s.null_resource.servers_install["machine"] (remote-exec): /tmp/terraform_931163766.sh: line 3: kubectl: command not found