### PR TITLE
export IPv6 addresses properly in output variables

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "kubernetes" {
     cluster_ca_certificate = local.cluster_ca_certificate
     client_certificate     = local.client_certificate
     client_key             = local.client_key
-    api_endpoint           = "https://${local.root_server_connection.host}:6443"
+    api_endpoint           = "https://${local.root_advertise_ip_k3s}:6443"
     password               = null
     username               = null
   }
@@ -18,7 +18,7 @@ output "kube_config" {
     clusters = [{
       cluster = {
         certificate-authority-data = base64encode(local.cluster_ca_certificate)
-        server                     = "https://${local.root_server_connection.host}:6443"
+        server                     = "https://${local.root_advertise_ip_k3s}:6443"
       }
       name = var.cluster_domain
     }]

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -6,7 +6,7 @@ locals {
   root_advertise_ip = split(",", values(var.servers)[0].ip)[0]
 
   // If root_advertise_ip is IPv6 wrap it in square brackets for IPv6 K3S URLs otherwise leave it raw
-  root_advertise_ip_k3s = can(regex("::", local.root_advertise_ip)) ? "[${local.root_advertise_ip}]" : local.root_advertise_ip
+  root_advertise_ip_k3s = can(regex(":", local.root_advertise_ip)) ? "[${local.root_advertise_ip}]" : local.root_advertise_ip
 
   // string representation of all specified extra k3s installation env vars
   install_env_vars = join(" ", [for k, v in var.k3s_install_env_vars : "${k}=${v}"])


### PR DESCRIPTION
Hi,

thanks for providing this great module!

I tried to create an IPv6 only cluster. It was created successfully, but the ip addresses in the output variables were not correctly put in square brackets. 

This PR makes use of the already existing variable root_advertise_ip_k3s. The problem was basically already solved, but not in all places.

Br,
Marcel