### PR TITLE
Fix node drain by replacing deprecated --delete-local-data flag

### DIFF
--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -168,7 +168,7 @@ resource "null_resource" "agents_drain" {
   provisioner "remote-exec" {
     when = destroy
     inline = [
-      "${self.triggers.kubectl_cmd} drain ${self.triggers.agent_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
+      "${self.triggers.kubectl_cmd} drain ${self.triggers.agent_name} --delete-emptydir-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
     ]
   }
 }

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -270,7 +270,7 @@ resource "null_resource" "servers_drain" {
   provisioner "remote-exec" {
     when = destroy
     inline = [
-      "${self.triggers.kubectl_cmd} drain ${self.triggers.server_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
+      "${self.triggers.kubectl_cmd} drain ${self.triggers.server_name} --delete-emptydir-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
     ]
   }
 }


### PR DESCRIPTION
Currently, when running ``tofu destroy``, the node drain fails with the following error:

```
module.k3s_cluster.null_resource.servers_label["cp1|environment"] (remote-exec): Connected!
module.k3s_cluster.null_resource.servers_drain["cp1"] (remote-exec): error: unknown flag: --delete-local-data
module.k3s_cluster.null_resource.servers_drain["cp1"] (remote-exec): See 'kubectl drain --help' for usage.
module.k3s_cluster.null_resource.servers_label["cp1|environment"] (remote-exec): node/cp1 unlabeled
module.k3s_cluster.null_resource.servers_label["cp1|environment"]: Destruction complete after 1s
╷
│ Error: remote-exec provisioner error
│
│   with module.k3s_cluster.null_resource.servers_drain["cp1"],
│   on .terraform/modules/k3s_cluster/server_nodes.tf line 268, in resource "null_resource" "servers_drain":
│  268:   provisioner "remote-exec" {
│
│ error executing "/tmp/terraform_902530670.sh": Process exited with status 1
```
This error is caused by the ``--delete-local-data`` flag, which has been deprecated and renamed to ``--delete-emptydir-data``.

This PR renames this flag, which will fix the node drain errors.