### PR TITLE
Adjusted drain to reflect deprecation of --delete-local-data

### DIFF
--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -270,7 +270,7 @@ resource "null_resource" "servers_drain" {
   provisioner "remote-exec" {
     when = destroy
     inline = [
-      "${self.triggers.kubectl_cmd} drain ${self.triggers.server_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
+      "${self.triggers.kubectl_cmd} drain ${self.triggers.server_name} --delete-emptydir-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
     ]
   }
 }


### PR DESCRIPTION
--delete-local-data is deprecated and needs to be replaced by: --delete-emptydir-data

This triggers when you destroy the cluster, because kubectl exits with an 1, because the param --delete-local-data does not exist anymore with kubectl nowadays (1.31)

**Testen on digitalocean Ubuntu 24.04. LTS **

![image](https://github.com/user-attachments/assets/df96a9a1-0d69-47e1-93fe-368c5a96e427)

