### PR TITLE
Update delete-local-data flag for drain to use delete-emptydir-data

### DIFF
--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -168,7 +168,7 @@ resource "null_resource" "agents_drain" {
   provisioner "remote-exec" {
     when = destroy
     inline = [
-      "${self.triggers.kubectl_cmd} drain ${self.triggers.agent_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
+      "${self.triggers.kubectl_cmd} drain ${self.triggers.agent_name} --delete-emptydir-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
     ]
   }
 }

--- a/server_nodes.tf
+++ b/server_nodes.tf
@@ -270,7 +270,7 @@ resource "null_resource" "servers_drain" {
   provisioner "remote-exec" {
     when = destroy
     inline = [
-      "${self.triggers.kubectl_cmd} drain ${self.triggers.server_name} --delete-local-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
+      "${self.triggers.kubectl_cmd} drain ${self.triggers.server_name} --delete-emptydir-data --force --ignore-daemonsets --timeout=${self.triggers.drain_timeout}"
     ]
   }
 }


### PR DESCRIPTION
The flag --delete-local-data is no longer a valid flag when performing a drain. The replacement flag is --delete-emtpydir-data.
