### PR TITLE
feat: filter tls_san from global as k3s no longer accepts for agents

### DIFF
--- a/agent_nodes.tf
+++ b/agent_nodes.tf
@@ -35,6 +35,8 @@ locals {
   ])
   agent_taints = local.managed_taint_enabled ? { for o in local.agent_taints_list : o.key => o.value if o.key != "" } : {}
 
+  agent_flags = [for f in var.global_flags : f if !startswith(f, "--tls-san")]
+
   // Generate a map of all calculated agent fields, used during k3s installation.
   agents_metadata = {
     for key, agent in var.agents :
@@ -49,14 +51,14 @@ locals {
           "--server https://${local.root_advertise_ip_k3s}:6443",
           "--token ${nonsensitive(random_password.k3s_cluster_secret.result)}", # NOTE: nonsensitive is used to show logs during provisioning
         ],
-        var.global_flags,
+        local.agent_flags,
         try(agent.flags, []),
         [for key, value in try(agent.taints, {}) : "--node-taint '${key}=${value}'" if value != null]
       )))
 
       immutable_fields_hash = sha1(join("", concat(
         [var.cluster_domain],
-        var.global_flags,
+        local.agent_flags,
         try(agent.flags, []),
       )))
     }


### PR DESCRIPTION
This PR filters the values in global_flags to remove `tls_san`: I'm sure there will be others, but this flag I noticed in my deploy is not longer accepted by k3s installer in the `1.36.1+k3s1` release.

Before this change, the `apply` would run for a very long time with agents, then ultimately fail.  Logs on the victim hosts (journalctl IIRC) showed that the `tls_san` option was refused by the installer for agents.  After this change, install completed as expected.

To re-iterate: there may be more flags in future, but this one fixes me, so I wrote this fix in a way that could be extended for multiple flags over time.